### PR TITLE
(feat): improve IsDisplayService and IsDisplayDirective to be able to check for at-least and at-most as well

### DIFF
--- a/packages/akita-read/package.json
+++ b/packages/akita-read/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cloudflight/akita-read",
-    "version": "0.5.2",
+    "version": "0.6.0",
     "keywords": [
         "akita-read",
         "akita"

--- a/packages/angular-display/README.md
+++ b/packages/angular-display/README.md
@@ -13,3 +13,23 @@ yarn add @cloudflight/angular-display
 # or
 pnpm add @cloudflight/angular-display
 ```
+
+## Configuration
+
+To use the library in a typesafe way you need to extend the `Breakpoints` interface using declaration merging.
+The interface is exposed in the global namespace `ClfIsDisplay`.
+
+Add the following to a `.d.ts` file that is picked up by the compiler:
+
+```ts
+declare namespace ClfIsDisplay {
+    export interface Breakpoints {
+        some: number;
+        breakpoint: number;
+        definitions: number;
+        here: number;
+    }
+}
+```
+
+For more information check the documentation of [ClfIsDisplay.Breakpoints]()

--- a/packages/angular-display/lax/README.md
+++ b/packages/angular-display/lax/README.md
@@ -1,0 +1,6 @@
+# @cloudflight/angular-display/lax
+
+Secondary entry point of `@cloudflight/angular-display`. It can be used by importing from `@cloudflight/angular-display/lax`.
+
+It provides the whole library in a non-typesafe way. Meaning you do not get any compile errors when using undefined breakpoints.
+But you also do not need to extend the Breakpoints type in the ClfIsDisplay namespace, simplifying the setup of the library.

--- a/packages/angular-display/lax/ng-package.json
+++ b/packages/angular-display/lax/ng-package.json
@@ -1,0 +1,5 @@
+{
+    "lib": {
+        "entryFile": "src/index.ts"
+    }
+}

--- a/packages/angular-display/lax/src/index.ts
+++ b/packages/angular-display/lax/src/index.ts
@@ -1,0 +1,14 @@
+// eslint-disable-next-line @nx/enforce-module-boundaries
+export * from '@cloudflight/angular-display';
+
+/* eslint-disable @typescript-eslint/no-namespace,@typescript-eslint/no-empty-interface */
+declare global {
+    export namespace ClfIsDisplay {
+        /**
+         * Redefines Breakpoints to disable type-safety.
+         * Prefer to use the typesafe option of this library. see {@link @cloudflight/angular-display#ClfIsDisplay.Breakpoints}
+         */
+        export interface Breakpoints extends Record<string, number> {}
+    }
+}
+/* eslint-enable */

--- a/packages/angular-display/package.json
+++ b/packages/angular-display/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cloudflight/angular-display",
-    "version": "0.5.2",
+    "version": "0.6.0",
     "keywords": [
         "angular-display",
         "breakpoints"
@@ -16,6 +16,8 @@
     },
     "peerDependencies": {
         "@angular/common": "^16.0.3",
-        "@angular/core": "^16.0.3"
+        "@angular/core": "^16.0.3",
+        "@angular/platform-browser": "^16.0.3",
+        "rxjs": "^7.4.0"
     }
 }

--- a/packages/angular-display/src/index.ts
+++ b/packages/angular-display/src/index.ts
@@ -1,4 +1,8 @@
 export {DisplayModule} from './lib/display.module';
+export {provideIsDisplay} from './lib/display.provider';
 
+export {Breakpoints, Breakpoint} from './lib/model/breakpoints';
 export {IsDisplayDirective} from './lib/directive/is-display.directive';
+export {IsDisplayPipe} from './lib/pipe/is-display.pipe';
 export {IsDisplayService} from './lib/service/is-display.service';
+export {ValidOption} from './lib/shared/display-option.adapter';

--- a/packages/angular-display/src/lib/directive/is-display.directive.spec.ts
+++ b/packages/angular-display/src/lib/directive/is-display.directive.spec.ts
@@ -4,12 +4,24 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {createSpyFromClass} from 'jest-auto-spies';
 import {BehaviorSubject, Observable, of, Subject} from 'rxjs';
+import {Breakpoint} from '../model/breakpoints';
 import {IsDisplayService} from '../service/is-display.service';
 import {IsDisplayDirective} from './is-display.directive';
 
+declare global {
+    // eslint-disable-next-line @typescript-eslint/no-namespace
+    namespace ClfIsDisplay {
+        export interface Breakpoints {
+            phone: number;
+            tablet: number;
+            desktop: number;
+        }
+    }
+}
+
 describe('IsDisplayDirective', () => {
     const isDisplayServiceMock = createSpyFromClass(IsDisplayService);
-    const breakpoints: Record<string, Subject<boolean>> = {
+    const breakpoints: Record<Breakpoint, Subject<boolean>> = {
         // eslint-disable-next-line rxjs/finnish
         phone: new BehaviorSubject<boolean>(false),
         // eslint-disable-next-line rxjs/finnish
@@ -18,60 +30,217 @@ describe('IsDisplayDirective', () => {
         desktop: new BehaviorSubject<boolean>(false),
     };
 
+    const isAtLeast$ = new BehaviorSubject(false);
+    const isAtMost$ = new BehaviorSubject(false);
+
     beforeEach(() => {
         jest.clearAllMocks();
 
         Object.values(breakpoints).forEach((subject$) => {
             subject$.next(false);
         });
+        isAtLeast$.next(false);
+        isAtMost$.next(false);
 
-        isDisplayServiceMock.isDisplay$.mockImplementation((option: string): Observable<boolean> => {
+        isDisplayServiceMock.isDisplay$.mockImplementation((option: Breakpoint): Observable<boolean> => {
             return breakpoints[option]?.asObservable() ?? of(false);
+        });
+
+        isDisplayServiceMock.isDisplayAtLeast$.mockReturnValue(isAtLeast$);
+        isDisplayServiceMock.isDisplayAtMost$.mockReturnValue(isAtMost$);
+    });
+
+    describe.each(Object.entries(breakpoints))('given the %s breakpoint', (rawBreakpoint: string, currentBreakpoint$) => {
+        const breakpoint = rawBreakpoint as Breakpoint;
+
+        describe('using the normal option syntax', () => {
+            @Component({
+                selector: 'clf-complex',
+                template: ` <span>{{ content }}</span> `,
+                changeDetection: ChangeDetectionStrategy.OnPush,
+            })
+            class ComplexComponent {
+                @Input({required: true})
+                public content!: string;
+            }
+
+            const content = 'The Conent';
+
+            @Component({
+                template: `
+                    <div id="display-only" *clfIsDisplay="'${breakpoint}'">display-only</div>
+                    <div id="display-implicit-then" *clfIsDisplay="'${breakpoint}'; else implicitNotDisplay">implicit then</div>
+                    <ng-template #implicitNotDisplay>
+                        <div id="display-implicit-else">implicit else</div>
+                    </ng-template>
+                    <div *clfIsDisplay="'${breakpoint}'; then explicitDisplay; else explicitNotDisplay"></div>
+                    <ng-template #explicitDisplay>
+                        <div id="display-explicit-then">explicit then</div>
+                    </ng-template>
+                    <ng-template #explicitNotDisplay>
+                        <div id="display-explicit-else">explicit else</div>
+                    </ng-template>
+                    <clf-complex *clfIsDisplay="'${breakpoint}'" [content]="content"></clf-complex>
+                `,
+                changeDetection: ChangeDetectionStrategy.OnPush,
+            })
+            class NormalBreakpointComponent {
+                protected readonly content = content;
+            }
+
+            let fixture: ComponentFixture<NormalBreakpointComponent>;
+
+            beforeEach(() => {
+                fixture = TestBed.configureTestingModule({
+                    imports: [IsDisplayDirective],
+                    declarations: [NormalBreakpointComponent, ComplexComponent],
+                    providers: [{provide: IsDisplayService, useValue: isDisplayServiceMock}],
+                }).createComponent(NormalBreakpointComponent);
+                fixture.detectChanges();
+            });
+
+            describe('when there is no value emitted yet', () => {
+                test('should not display display-only', () => {
+                    const element = fixture.debugElement.query(By.css('#display-only'));
+                    expect(element).toBeNull();
+                });
+
+                test('should display display-implicit-else', () => {
+                    const thenElement = fixture.debugElement.query(By.css('#display-implicit-then'));
+                    expect(thenElement).toBeNull();
+                    const elseElement = fixture.debugElement.query(By.css('#display-implicit-else'));
+                    expect(elseElement).not.toBeNull();
+                });
+
+                test('should display display-explicit-else', () => {
+                    const thenElement = fixture.debugElement.query(By.css('#display-explicit-then'));
+                    expect(thenElement).toBeNull();
+                    const elseElement = fixture.debugElement.query(By.css('#display-explicit-else'));
+                    expect(elseElement).not.toBeNull();
+                });
+
+                test('should not display the complex component', () => {
+                    const complexElement = fixture.debugElement.query(By.css('clf-complex'));
+                    expect(complexElement).toBeNull();
+                });
+            });
+
+            describe('when emitting a value the displayed part should change', () => {
+                test('should display display-only', () => {
+                    currentBreakpoint$.next(false);
+                    fixture.detectChanges();
+                    let element = fixture.debugElement.query(By.css('#display-only'));
+                    expect(element).toBeNull();
+
+                    currentBreakpoint$.next(true);
+                    fixture.detectChanges();
+                    element = fixture.debugElement.query(By.css('#display-only'));
+                    expect(element).not.toBeNull();
+                });
+
+                test('should not display display-implicit-else', () => {
+                    currentBreakpoint$.next(false);
+                    fixture.detectChanges();
+                    let thenElement = fixture.debugElement.query(By.css('#display-implicit-then'));
+                    expect(thenElement).toBeNull();
+                    let elseElement = fixture.debugElement.query(By.css('#display-implicit-else'));
+                    expect(elseElement).not.toBeNull();
+
+                    currentBreakpoint$.next(true);
+                    fixture.detectChanges();
+                    thenElement = fixture.debugElement.query(By.css('#display-implicit-then'));
+                    expect(thenElement).not.toBeNull();
+                    elseElement = fixture.debugElement.query(By.css('#display-implicit-else'));
+                    expect(elseElement).toBeNull();
+                });
+
+                test('should not display display-explicit-else', () => {
+                    currentBreakpoint$.next(false);
+                    fixture.detectChanges();
+                    let thenElement = fixture.debugElement.query(By.css('#display-explicit-then'));
+                    expect(thenElement).toBeNull();
+                    let elseElement = fixture.debugElement.query(By.css('#display-explicit-else'));
+                    expect(elseElement).not.toBeNull();
+
+                    currentBreakpoint$.next(true);
+                    fixture.detectChanges();
+                    thenElement = fixture.debugElement.query(By.css('#display-explicit-then'));
+                    expect(thenElement).not.toBeNull();
+                    elseElement = fixture.debugElement.query(By.css('#display-explicit-else'));
+                    expect(elseElement).toBeNull();
+                });
+
+                test('should display the complex component correctly', () => {
+                    currentBreakpoint$.next(false);
+                    fixture.detectChanges();
+                    let complexElement = fixture.debugElement.query(By.css('clf-complex'));
+                    expect(complexElement).toBeNull();
+
+                    currentBreakpoint$.next(true);
+                    fixture.detectChanges();
+                    complexElement = fixture.debugElement.query(By.css('clf-complex'));
+                    expect(complexElement).not.toBeNull();
+                    expect(complexElement.nativeElement.textContent).toEqual(content);
+                });
+            });
+        });
+
+        describe('using the inverted option syntax', () => {
+            @Component({
+                template: ` <div id="display-only" *clfIsDisplay="'!${breakpoint}'">display-only</div> `,
+                changeDetection: ChangeDetectionStrategy.OnPush,
+            })
+            class InvertedBreakpointComponent {}
+
+            let fixture: ComponentFixture<InvertedBreakpointComponent>;
+
+            beforeEach(() => {
+                fixture = TestBed.configureTestingModule({
+                    imports: [IsDisplayDirective],
+                    declarations: [InvertedBreakpointComponent],
+                    providers: [{provide: IsDisplayService, useValue: isDisplayServiceMock}],
+                }).createComponent(InvertedBreakpointComponent);
+                fixture.detectChanges();
+            });
+
+            describe('when there is no value emitted yet', () => {
+                test('should display display-only', () => {
+                    const element = fixture.debugElement.query(By.css('#display-only'));
+                    expect(element).not.toBeNull();
+                });
+            });
+
+            describe('when emitting a value the displayed part should change', () => {
+                test('should display display-only', () => {
+                    currentBreakpoint$.next(true);
+                    fixture.detectChanges();
+                    let element = fixture.debugElement.query(By.css('#display-only'));
+                    expect(element).toBeNull();
+
+                    currentBreakpoint$.next(false);
+                    fixture.detectChanges();
+                    element = fixture.debugElement.query(By.css('#display-only'));
+                    expect(element).not.toBeNull();
+                });
+            });
         });
     });
 
-    describe.each(Object.entries(breakpoints))('given a component using the %s breakpoint', (breakpoint, currentBreakpoint$) => {
+    describe('using the less then or equal syntax with the tablet breakpoint', () => {
         @Component({
-            selector: 'clf-complex',
-            template: ` <span>{{ content }}</span> `,
+            template: ` <div id="display-only" *clfIsDisplay="'<=tablet'">display-only</div> `,
             changeDetection: ChangeDetectionStrategy.OnPush,
         })
-        class ComplexComponent {
-            @Input({required: true})
-            public content!: string;
-        }
+        class InvertedBreakpointComponent {}
 
-        const content = 'The Conent';
-
-        @Component({
-            template: `
-                <div id="display-only" *clfIsDisplay="'${breakpoint}'">display-only</div>
-                <div id="display-implicit-then" *clfIsDisplay="'${breakpoint}'; else implicitNotDisplay">implicit then</div>
-                <ng-template #implicitNotDisplay>
-                    <div id="display-implicit-else">implicit else</div>
-                </ng-template>
-                <div *clfIsDisplay="'${breakpoint}'; then explicitDisplay; else explicitNotDisplay"></div>
-                <ng-template #explicitDisplay>
-                    <div id="display-explicit-then">explicit then</div>
-                </ng-template>
-                <ng-template #explicitNotDisplay>
-                    <div id="display-explicit-else">explicit else</div>
-                </ng-template>
-                <clf-complex *clfIsDisplay="'${breakpoint}'" [content]="content"></clf-complex>
-            `,
-            changeDetection: ChangeDetectionStrategy.OnPush,
-        })
-        class BreakpointComponent {
-            protected readonly content = content;
-        }
-
-        let fixture: ComponentFixture<BreakpointComponent>;
+        let fixture: ComponentFixture<InvertedBreakpointComponent>;
 
         beforeEach(() => {
             fixture = TestBed.configureTestingModule({
-                declarations: [BreakpointComponent, ComplexComponent, IsDisplayDirective],
+                imports: [IsDisplayDirective],
+                declarations: [InvertedBreakpointComponent],
                 providers: [{provide: IsDisplayService, useValue: isDisplayServiceMock}],
-            }).createComponent(BreakpointComponent);
+            }).createComponent(InvertedBreakpointComponent);
             fixture.detectChanges();
         });
 
@@ -80,83 +249,59 @@ describe('IsDisplayDirective', () => {
                 const element = fixture.debugElement.query(By.css('#display-only'));
                 expect(element).toBeNull();
             });
+        });
 
-            test('should display display-implicit-else', () => {
-                const thenElement = fixture.debugElement.query(By.css('#display-implicit-then'));
-                expect(thenElement).toBeNull();
-                const elseElement = fixture.debugElement.query(By.css('#display-implicit-else'));
-                expect(elseElement).not.toBeNull();
+        describe('when emitting a value the displayed part should change', () => {
+            test('should display display-only', () => {
+                isAtMost$.next(false);
+                fixture.detectChanges();
+                let element = fixture.debugElement.query(By.css('#display-only'));
+                expect(element).toBeNull();
+
+                isAtMost$.next(true);
+                fixture.detectChanges();
+                element = fixture.debugElement.query(By.css('#display-only'));
+                expect(element).not.toBeNull();
             });
+        });
+    });
 
-            test('should display display-explicit-else', () => {
-                const thenElement = fixture.debugElement.query(By.css('#display-explicit-then'));
-                expect(thenElement).toBeNull();
-                const elseElement = fixture.debugElement.query(By.css('#display-explicit-else'));
-                expect(elseElement).not.toBeNull();
-            });
+    describe('using the more then or equal syntax with the tablet breakpoint', () => {
+        @Component({
+            template: ` <div id="display-only" *clfIsDisplay="'>=tablet'">display-only</div> `,
+            changeDetection: ChangeDetectionStrategy.OnPush,
+        })
+        class InvertedBreakpointComponent {}
 
-            test('should not display the complex component', () => {
-                const complexElement = fixture.debugElement.query(By.css('clf-complex'));
-                expect(complexElement).toBeNull();
+        let fixture: ComponentFixture<InvertedBreakpointComponent>;
+
+        beforeEach(() => {
+            fixture = TestBed.configureTestingModule({
+                imports: [IsDisplayDirective],
+                declarations: [InvertedBreakpointComponent],
+                providers: [{provide: IsDisplayService, useValue: isDisplayServiceMock}],
+            }).createComponent(InvertedBreakpointComponent);
+            fixture.detectChanges();
+        });
+
+        describe('when there is no value emitted yet', () => {
+            test('should not display display-only', () => {
+                const element = fixture.debugElement.query(By.css('#display-only'));
+                expect(element).toBeNull();
             });
         });
 
         describe('when emitting a value the displayed part should change', () => {
             test('should display display-only', () => {
-                currentBreakpoint$.next(false);
+                isAtLeast$.next(false);
                 fixture.detectChanges();
                 let element = fixture.debugElement.query(By.css('#display-only'));
                 expect(element).toBeNull();
 
-                currentBreakpoint$.next(true);
+                isAtLeast$.next(true);
                 fixture.detectChanges();
                 element = fixture.debugElement.query(By.css('#display-only'));
                 expect(element).not.toBeNull();
-            });
-
-            test('should not display display-implicit-else', () => {
-                currentBreakpoint$.next(false);
-                fixture.detectChanges();
-                let thenElement = fixture.debugElement.query(By.css('#display-implicit-then'));
-                expect(thenElement).toBeNull();
-                let elseElement = fixture.debugElement.query(By.css('#display-implicit-else'));
-                expect(elseElement).not.toBeNull();
-
-                currentBreakpoint$.next(true);
-                fixture.detectChanges();
-                thenElement = fixture.debugElement.query(By.css('#display-implicit-then'));
-                expect(thenElement).not.toBeNull();
-                elseElement = fixture.debugElement.query(By.css('#display-implicit-else'));
-                expect(elseElement).toBeNull();
-            });
-
-            test('should not display display-explicit-else', () => {
-                currentBreakpoint$.next(false);
-                fixture.detectChanges();
-                let thenElement = fixture.debugElement.query(By.css('#display-explicit-then'));
-                expect(thenElement).toBeNull();
-                let elseElement = fixture.debugElement.query(By.css('#display-explicit-else'));
-                expect(elseElement).not.toBeNull();
-
-                currentBreakpoint$.next(true);
-                fixture.detectChanges();
-                thenElement = fixture.debugElement.query(By.css('#display-explicit-then'));
-                expect(thenElement).not.toBeNull();
-                elseElement = fixture.debugElement.query(By.css('#display-explicit-else'));
-                expect(elseElement).toBeNull();
-            });
-
-            test('should display the complex component correctly', () => {
-                currentBreakpoint$.next(false);
-                fixture.detectChanges();
-                let complexElement = fixture.debugElement.query(By.css('clf-complex'));
-                expect(complexElement).toBeNull();
-
-                currentBreakpoint$.next(true);
-                fixture.detectChanges();
-                complexElement = fixture.debugElement.query(By.css('clf-complex'));
-                expect(complexElement).not.toBeNull();
-                expect(complexElement.nativeElement.textContent).toEqual(content);
             });
         });
     });

--- a/packages/angular-display/src/lib/display.module.ts
+++ b/packages/angular-display/src/lib/display.module.ts
@@ -1,44 +1,26 @@
 import {ModuleWithProviders, NgModule} from '@angular/core';
 import {IsDisplayDirective} from './directive/is-display.directive';
-import {Breakpoints, breakpointsInjectionToken} from './model/breakpoints';
+import {provideIsDisplay} from './display.provider';
+import {Breakpoints} from './model/breakpoints';
+import {IsDisplayPipe} from './pipe/is-display.pipe';
 
+/**
+ * @deprecated prefer to use the standalone configuration. see {@link provideIsDisplay}
+ * @see {@link provideIsDisplay}
+ */
 @NgModule({
-    declarations: [IsDisplayDirective],
-    exports: [IsDisplayDirective],
+    imports: [IsDisplayDirective, IsDisplayPipe],
+    exports: [IsDisplayDirective, IsDisplayPipe],
 })
 export class DisplayModule {
     /**
-     * Configures names and sizes of breakpoints used by this module. For example
-     * ```ts
-     * {
-     *   small: 480,
-     *   medium: 800,
-     *   big: 1024,
-     * };
-     * ```
-     *
-     * These names can then be used for {@link IsDisplayDirective} and {@link IsDisplayService}.
-     *
-     * Additionally, these values will also be available as css custom properties.
-     * Which is equivalent as having the following defined:
-     * ```css
-     * :root {
-     *   --breakpoint-small: 480px;
-     *   --breakpoint-medium: 800px;
-     *   --breakpoint-big: 1024px;
-     * }
-     * ```
+     * @deprecated prefer to use the standalone configuration. see {@link provideIsDisplay}
+     * @see {@link provideIsDisplay}
      */
-
     public static forRoot(breakpoints: Breakpoints): ModuleWithProviders<DisplayModule> {
         return {
             ngModule: DisplayModule,
-            providers: [
-                {
-                    provide: breakpointsInjectionToken,
-                    useValue: breakpoints,
-                },
-            ],
+            providers: [provideIsDisplay(breakpoints)],
         };
     }
 }

--- a/packages/angular-display/src/lib/display.provider.ts
+++ b/packages/angular-display/src/lib/display.provider.ts
@@ -1,0 +1,27 @@
+import {EnvironmentProviders, makeEnvironmentProviders} from '@angular/core';
+import {Breakpoints, breakpointsInjectionToken} from './model/breakpoints';
+
+/**
+ * Configures names and sizes of breakpoints used by this module. For example
+ * ```ts
+ * {
+ *   small: 480,
+ *   medium: 800,
+ *   big: 1024,
+ * };
+ * ```
+ *
+ * These names can then be used for {@link IsDisplayDirective}, {@link IsDisplayPipe} and {@link IsDisplayService}.
+ *
+ * To provide type-safety you need to define an application-specific extension using interface merging. For more information on this see {@link ClfIsDisplay.Breakpoints}
+ *
+ * @see {@link ClfIsDisplay.Breakpoints}
+ */
+export function provideIsDisplay(breakpoints: Breakpoints): EnvironmentProviders {
+    return makeEnvironmentProviders([
+        {
+            provide: breakpointsInjectionToken,
+            useValue: breakpoints,
+        },
+    ]);
+}

--- a/packages/angular-display/src/lib/model/breakpoints.ts
+++ b/packages/angular-display/src/lib/model/breakpoints.ts
@@ -1,5 +1,51 @@
 import {InjectionToken} from '@angular/core';
 
-export type Breakpoints = Readonly<Record<string, number>>;
+/* eslint-disable @typescript-eslint/no-namespace,@typescript-eslint/no-empty-interface */
+declare global {
+    /**
+     * This global namespace allows the using application to extend the Breakpoints type,
+     * so that the whole library can be used in a typesafe way.
+     *
+     * Note: this mechanism was inspired by: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/express-serve-static-core/index.d.ts
+     */
+    export namespace ClfIsDisplay {
+        /**
+         * This interface may be extended in an application-specific manner via declaration merging.
+         *
+         * To do this create a .d.ts file that is added to your compilation by using the `file` or `include` property in your tsconfig.json.
+         * Add the following to this file:
+         *
+         * ```ts
+         * declare namespace ClfIsDisplay {
+         *     export interface Breakpoints {
+         *         some: number;
+         *         breakpoint: number;
+         *         definitions: number;
+         *         here: number;
+         *     }
+         * }
+         * ```
+         *
+         * By doing this the breakpoints and breakpoint queries you pass to this library will be completely typesafe.
+         *
+         * If you don't want to do this, you can instead use the relaxed version of this library that does not provide type-safety.
+         * For that replace all imports of the library with the relaxed entry-point `@cloudflight/angular-display/lax`.
+         */
+        interface Breakpoints {}
+    }
+}
+/* eslint-enable */
+
+/**
+ * Contains all available breakpoints definitions. To define application-specific breakpoints check {@link ClfIsDisplay.Breakpoints}
+ *
+ * @see {@link ClfIsDisplay.Breakpoints}
+ */
+export type Breakpoints = ClfIsDisplay.Breakpoints;
+
+/**
+ * Represents all available breakpoint identifiers.
+ */
+export type Breakpoint = keyof Breakpoints;
 
 export const breakpointsInjectionToken = new InjectionToken<Breakpoints>('breakpointsInjectionToken ');

--- a/packages/angular-display/src/lib/pipe/is-display.pipe.spec.ts
+++ b/packages/angular-display/src/lib/pipe/is-display.pipe.spec.ts
@@ -1,0 +1,194 @@
+import {ChangeDetectorRef} from '@angular/core';
+import {createSpyFromClass, Spy} from 'jest-auto-spies';
+import {Subject} from 'rxjs';
+import {IsDisplayService} from '../service/is-display.service';
+import {IsDisplayPipe} from './is-display.pipe';
+
+declare global {
+    // eslint-disable-next-line @typescript-eslint/no-namespace
+    namespace ClfIsDisplay {
+        export interface Breakpoints {
+            phone: number;
+            tablet: number;
+            desktop: number;
+        }
+    }
+}
+
+describe('IsDisplayPipe', () => {
+    let isDisplayServiceMock: Spy<IsDisplayService>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- this is the recommended way to mock abstract classes
+    const changeDetectionRefMock = createSpyFromClass<ChangeDetectorRef>(ChangeDetectorRef as any, ['markForCheck']);
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        isDisplayServiceMock = createSpyFromClass(IsDisplayService);
+    });
+
+    describe('Given a IsDisplayPipe', () => {
+        let pipe: IsDisplayPipe;
+
+        beforeEach(() => {
+            pipe = new IsDisplayPipe(changeDetectionRefMock, isDisplayServiceMock);
+        });
+
+        afterEach(() => {
+            // make sure the pipe unsubscribes from the observable
+            pipe.ngOnDestroy();
+        });
+
+        describe('When checking for the exact breakpoint', () => {
+            let isDisplay$: Subject<boolean>;
+
+            beforeEach(() => {
+                isDisplay$ = isDisplayServiceMock.isDisplay$.returnSubject();
+            });
+
+            it('should initially return false if no emit happened', () => {
+                const actual = pipe.transform('phone');
+                expect(actual).toBe(false);
+            });
+
+            it('should return the emitted value after it emitted once', () => {
+                pipe.transform('phone');
+                isDisplay$.next(true);
+
+                const actual = pipe.transform('phone');
+                expect(actual).toBe(true);
+            });
+
+            it('should return the latest emitted value after it emitted multiple times', () => {
+                pipe.transform('phone');
+                isDisplay$.next(true);
+                isDisplay$.next(true);
+                isDisplay$.next(false);
+
+                const actual = pipe.transform('phone');
+                expect(actual).toBe(false);
+            });
+        });
+
+        describe('When checking for the negated breakpoint', () => {
+            let isDisplay$: Subject<boolean>;
+
+            beforeEach(() => {
+                isDisplay$ = isDisplayServiceMock.isDisplay$.returnSubject();
+            });
+
+            it('should initially return false if no emit happened', () => {
+                const actual = pipe.transform('!phone');
+                expect(actual).toBe(false);
+            });
+
+            it('should return the emitted negated value after it emitted once', () => {
+                pipe.transform('!phone');
+                isDisplay$.next(false);
+
+                const actual = pipe.transform('!phone');
+                expect(actual).toBe(true);
+            });
+
+            it('should return the latest emitted negated value after it emitted multiple times', () => {
+                pipe.transform('!phone');
+                isDisplay$.next(true);
+                isDisplay$.next(true);
+                isDisplay$.next(false);
+
+                const actual = pipe.transform('!phone');
+                expect(actual).toBe(true);
+            });
+        });
+
+        describe('When checking for at most the breakpoint', () => {
+            let atMost$: Subject<boolean>;
+
+            beforeEach(() => {
+                atMost$ = isDisplayServiceMock.isDisplayAtMost$.returnSubject();
+            });
+
+            it('should initially return false if no emit happened', () => {
+                const actual = pipe.transform('<=phone');
+                expect(actual).toBe(false);
+            });
+
+            it('should return the emitted value after it emitted once', () => {
+                pipe.transform('<=phone');
+                atMost$.next(true);
+
+                const actual = pipe.transform('<=phone');
+                expect(actual).toBe(true);
+            });
+
+            it('should return the latest emitted value after it emitted multiple times', () => {
+                pipe.transform('<=phone');
+                atMost$.next(true);
+                atMost$.next(true);
+                atMost$.next(false);
+
+                const actual = pipe.transform('<=phone');
+                expect(actual).toBe(false);
+            });
+        });
+
+        describe('When checking for at least the breakpoint', () => {
+            let atLeast$: Subject<boolean>;
+
+            beforeEach(() => {
+                atLeast$ = isDisplayServiceMock.isDisplayAtLeast$.returnSubject();
+            });
+
+            it('should initially return false if no emit happened', () => {
+                const actual = pipe.transform('>=phone');
+                expect(actual).toBe(false);
+            });
+
+            it('should return the emitted value after it emitted once', () => {
+                pipe.transform('>=phone');
+                atLeast$.next(true);
+
+                const actual = pipe.transform('>=phone');
+                expect(actual).toBe(true);
+            });
+
+            it('should return the latest emitted value after it emitted multiple times', () => {
+                pipe.transform('>=phone');
+                atLeast$.next(true);
+                atLeast$.next(true);
+                atLeast$.next(false);
+
+                const actual = pipe.transform('>=phone');
+                expect(actual).toBe(false);
+            });
+        });
+
+        describe('When switching between different breakpoint queries', () => {
+            let isDisplay$: Subject<boolean>;
+            let atMost$: Subject<boolean>;
+            let atLeast$: Subject<boolean>;
+
+            beforeEach(() => {
+                isDisplay$ = isDisplayServiceMock.isDisplay$.returnSubject();
+                atMost$ = isDisplayServiceMock.isDisplayAtMost$.returnSubject();
+                atLeast$ = isDisplayServiceMock.isDisplayAtLeast$.returnSubject();
+            });
+
+            it('should return the latest emitted value of those queries', () => {
+                isDisplay$.next(true);
+                atMost$.next(false);
+                atLeast$.next(true);
+
+                const first = pipe.transform('phone');
+                expect(first).toBe(true);
+
+                const second = pipe.transform('<=phone');
+                expect(second).toBe(false);
+
+                atMost$.next(true);
+                atLeast$.next(false);
+
+                const third = pipe.transform('>=phone');
+                expect(third).toBe(false);
+            });
+        });
+    });
+});

--- a/packages/angular-display/src/lib/pipe/is-display.pipe.ts
+++ b/packages/angular-display/src/lib/pipe/is-display.pipe.ts
@@ -1,0 +1,57 @@
+import {ChangeDetectorRef, OnDestroy, Pipe, PipeTransform} from '@angular/core';
+import {ReplaySubject, switchMap, Unsubscribable} from 'rxjs';
+import {distinctUntilChanged} from 'rxjs/operators';
+import {IsDisplayService} from '../service/is-display.service';
+import {parseOption, ValidOption} from '../shared/display-option.adapter';
+
+/**
+ * Converts the provided breakpoint-query to a boolean value depending on the current display size.
+ * For the breakpoint-queries passed to this directive please consult {@link provideIsDisplay}.
+ *
+ * Example:
+ * ```html
+ * <span>
+ *     {{ 'small' | clfIsDisplay }}
+ * </span>
+ * ```
+ *
+ * The value automatically updates whenever the display size changes.
+ *
+ * @see {@link ValidOption}
+ * @see {@link provideIsDisplay}
+ */
+@Pipe({
+    name: 'clfIsDisplay',
+    standalone: true,
+    pure: false,
+})
+export class IsDisplayPipe implements PipeTransform, OnDestroy {
+    private isDisplay = false;
+    private option$ = new ReplaySubject<ValidOption>(1);
+    private subscription: Unsubscribable;
+
+    public constructor(private cdr: ChangeDetectorRef, isDisplayService: IsDisplayService) {
+        this.subscription = this.option$
+            .pipe(
+                distinctUntilChanged(),
+                switchMap((option: ValidOption) => {
+                    const adapter = parseOption(option, isDisplayService);
+                    return adapter.isDisplay$;
+                }),
+            )
+            .subscribe((isDisplay) => {
+                this.isDisplay = isDisplay;
+                this.cdr.markForCheck();
+            });
+    }
+
+    public transform(value: ValidOption): boolean {
+        this.option$.next(value);
+
+        return this.isDisplay;
+    }
+
+    public ngOnDestroy(): void {
+        this.subscription.unsubscribe();
+    }
+}

--- a/packages/angular-display/src/lib/service/is-display.service.spec.ts
+++ b/packages/angular-display/src/lib/service/is-display.service.spec.ts
@@ -58,7 +58,7 @@ class FakeMediaMatcher implements MediaMatcher {
 
     /** Fakes the match media response to be controlled in tests. */
     public matchMedia(query: string): FakeMediaQueryList {
-        const mql = new FakeMediaQueryList(true, query);
+        const mql = new FakeMediaQueryList(false, query);
         this.queries.set(query, mql);
         return mql;
     }
@@ -68,6 +68,18 @@ class FakeMediaMatcher implements MediaMatcher {
         if (this.queries.has(query)) {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             this.queries.get(query)!.setMatches(matches);
+        }
+    }
+}
+
+declare global {
+    // eslint-disable-next-line @typescript-eslint/no-namespace
+    namespace ClfIsDisplay {
+        export interface Breakpoints {
+            phone: number;
+            tablet: number;
+            desktop: number;
+            invalidValueKey?: string;
         }
     }
 }
@@ -83,7 +95,22 @@ describe('IsDisplayService', () => {
             desktop: 1024,
         };
 
-        isDisplayService = new IsDisplayService(breakPoints, fakeMediaMatcher, document);
+        isDisplayService = new IsDisplayService(breakPoints, fakeMediaMatcher);
+    });
+
+    describe('Given invalid configured Breakpoints', () => {
+        describe('When a invalid value type is used', () => {
+            const invalidBreakPoints: Breakpoints = {
+                phone: 0,
+                tablet: 1,
+                desktop: 2,
+                invalidValueKey: 'invalid',
+            };
+
+            test('should throw a error when initializing the IsDisplayService', () => {
+                expect(() => new IsDisplayService(invalidBreakPoints, fakeMediaMatcher)).toThrow();
+            });
+        });
     });
 
     describe('Given the phone media query', () => {
@@ -104,6 +131,22 @@ describe('IsDisplayService', () => {
 
             test(`should emit "${matches}" for isDisplay$('phone')`, async () => {
                 await expect(firstValueFrom(isDisplayService.isDisplay$('phone'))).resolves.toEqual(matches);
+            });
+
+            test(`should emit "false" for isDisplayAtLeast('tablet')`, () => {
+                expect(isDisplayService.isDisplayAtLeast('tablet')).toEqual(false);
+            });
+
+            test(`should emit "false" for isDisplayAtLeast$('tablet')`, async () => {
+                await expect(firstValueFrom(isDisplayService.isDisplayAtLeast$('tablet'))).resolves.toEqual(false);
+            });
+
+            test(`should emit "${matches}" for isDisplayAtMost('tablet')`, () => {
+                expect(isDisplayService.isDisplayAtMost('tablet')).toEqual(matches);
+            });
+
+            test(`should emit "${matches}" for isDisplayAtMost$('tablet')`, async () => {
+                await expect(firstValueFrom(isDisplayService.isDisplayAtMost$('tablet'))).resolves.toEqual(matches);
             });
         });
     });
@@ -127,6 +170,22 @@ describe('IsDisplayService', () => {
             test(`should emit "${matches}" for isDisplay$('tablet')`, async () => {
                 await expect(firstValueFrom(isDisplayService.isDisplay$('tablet'))).resolves.toEqual(matches);
             });
+
+            test(`should emit "${matches}" for isDisplayAtLeast('tablet')`, () => {
+                expect(isDisplayService.isDisplayAtLeast('tablet')).toEqual(matches);
+            });
+
+            test(`should emit "${matches}" for isDisplayAtLeast$('tablet')`, async () => {
+                await expect(firstValueFrom(isDisplayService.isDisplayAtLeast$('tablet'))).resolves.toEqual(matches);
+            });
+
+            test(`should emit "${matches}" for isDisplayAtMost('tablet')`, () => {
+                expect(isDisplayService.isDisplayAtMost('tablet')).toEqual(matches);
+            });
+
+            test(`should emit "${matches}" for isDisplayAtMost$('tablet')`, async () => {
+                await expect(firstValueFrom(isDisplayService.isDisplayAtMost$('tablet'))).resolves.toEqual(matches);
+            });
         });
     });
 
@@ -148,6 +207,22 @@ describe('IsDisplayService', () => {
 
             test(`should emit "${matches}" for isDisplay$('desktop')`, async () => {
                 await expect(firstValueFrom(isDisplayService.isDisplay$('desktop'))).resolves.toEqual(matches);
+            });
+
+            test(`should emit "${matches}" for isDisplayAtLeast('tablet')`, () => {
+                expect(isDisplayService.isDisplayAtLeast('tablet')).toEqual(matches);
+            });
+
+            test(`should emit "${matches}" for isDisplayAtLeast$('tablet')`, async () => {
+                await expect(firstValueFrom(isDisplayService.isDisplayAtLeast$('tablet'))).resolves.toEqual(matches);
+            });
+
+            test(`should emit "false" for isDisplayAtMost('tablet')`, () => {
+                expect(isDisplayService.isDisplayAtMost('tablet')).toEqual(false);
+            });
+
+            test(`should emit "false" for isDisplayAtMost$('tablet')`, async () => {
+                await expect(firstValueFrom(isDisplayService.isDisplayAtMost$('tablet'))).resolves.toEqual(false);
             });
         });
     });

--- a/packages/angular-display/src/lib/shared/display-option.adapter.ts
+++ b/packages/angular-display/src/lib/shared/display-option.adapter.ts
@@ -1,0 +1,67 @@
+import {map, Observable} from 'rxjs';
+import {Breakpoint} from '../model/breakpoints';
+import {IsDisplayService} from '../service/is-display.service';
+
+/**
+ * Represents all available breakpoint queries.
+ *
+ * Possible queries are: 'breakpoint', '!breakpoint', '<=breakpoint' and '>=breakpoint'.
+ */
+export type ValidOption = Breakpoint | `!${Breakpoint}` | `<=${Breakpoint}` | `>=${Breakpoint}`;
+
+/**
+ * @internal
+ */
+export interface OptionAdapter {
+    readonly isDisplay: boolean;
+    readonly isDisplay$: Observable<boolean>;
+}
+
+/**
+ * @internal
+ */
+export function parseOption(validOption: ValidOption, service: IsDisplayService): OptionAdapter {
+    // at runtime valid validOption is a string
+    const rawOption = validOption as string;
+    if (rawOption.startsWith('!')) {
+        const option = rawOption.slice(1) as Breakpoint;
+        return createInvertedOptionAdapter(option, service);
+    } else if (rawOption.startsWith('<=')) {
+        const option = rawOption.slice(2) as Breakpoint;
+        return createAtMostOptionAdapter(option, service);
+    } else if (rawOption.startsWith('>=')) {
+        const option = rawOption.slice(2) as Breakpoint;
+        return createAtLeastOptionAdapter(option, service);
+    } else {
+        const option = rawOption as Breakpoint;
+        return createNormalOptionAdapter(option, service);
+    }
+}
+
+function createNormalOptionAdapter(option: Breakpoint, service: IsDisplayService): OptionAdapter {
+    return {
+        isDisplay: service.isDisplay(option),
+        isDisplay$: service.isDisplay$(option),
+    };
+}
+
+function createInvertedOptionAdapter(option: Breakpoint, service: IsDisplayService): OptionAdapter {
+    return {
+        isDisplay: !service.isDisplay(option),
+        isDisplay$: service.isDisplay$(option).pipe(map((value) => !value)),
+    };
+}
+
+function createAtMostOptionAdapter(option: Breakpoint, service: IsDisplayService): OptionAdapter {
+    return {
+        isDisplay: service.isDisplayAtMost(option),
+        isDisplay$: service.isDisplayAtMost$(option),
+    };
+}
+
+function createAtLeastOptionAdapter(option: Breakpoint, service: IsDisplayService): OptionAdapter {
+    return {
+        isDisplay: service.isDisplayAtLeast(option),
+        isDisplay$: service.isDisplayAtLeast$(option),
+    };
+}

--- a/packages/angular-logger/package.json
+++ b/packages/angular-logger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cloudflight/angular-logger",
-    "version": "0.5.2",
+    "version": "0.6.0",
     "keywords": [
         "angular-logger",
         "logger"

--- a/packages/concurrency-utils/package.json
+++ b/packages/concurrency-utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cloudflight/concurrency-utils",
-    "version": "0.5.2",
+    "version": "0.6.0",
     "keywords": [
         "concurrency-utils",
         "concurrency",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cloudflight/logger",
-    "version": "0.5.2",
+    "version": "0.6.0",
     "keywords": [
         "logger"
     ],

--- a/packages/rxjs-read/package.json
+++ b/packages/rxjs-read/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cloudflight/rxjs-read",
-    "version": "0.5.2",
+    "version": "0.6.0",
     "keywords": [
         "rxjs"
     ],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -19,6 +19,7 @@
         "paths": {
             "@cloudflight/akita-read": ["packages/akita-read/src/index.ts"],
             "@cloudflight/angular-display": ["packages/angular-display/src/index.ts"],
+            "@cloudflight/angular-display/lax": ["packages/angular-display/lax/src/index.ts"],
             "@cloudflight/angular-logger": ["packages/angular-logger/src/index.ts"],
             "@cloudflight/concurrency-utils": ["packages/concurrency-utils/src/index.ts"],
             "@cloudflight/logger": ["packages/logger/src/index.ts"],


### PR DESCRIPTION
* breaking: Made the selectable breakpoints typesafe, this requires every using application to redefine the Breakpoints interface using typescripts interface merging mechanism
* add methods isDisplayAtMost and isDisplayAtLeast to IsDisplayService
* improve possible syntax for IsDisplayDirective to use '!', '>=' and '<=' in front of the selected breakpoint
* add IsDisplayPipe to transform a breakpoint query to a boolean value indicating if the query is met or not
* update documentation
* add secondary entry-point to expose the library in a non-typesafe version as well